### PR TITLE
Create Cluster with Name === cluster_name

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -105,7 +105,7 @@ resource "aws_autoscaling_group" "cluster" {
 }
 
 resource "aws_ecs_cluster" "cluster" {
-  name = "${var.component}-${var.deployment_identifier}-${var.cluster_name}"
+  name = "${var.cluster_name}"
 
   depends_on = [null_resource.iam_wait]
 


### PR DESCRIPTION
Fix for Issue #12 

It was naming the cluster using the nomenclature <component>-<deployment_identifier>-<cluster_name> but creating security groups and EC2 Instances with the nomenclature <cluster_name>. 