### PR TITLE
Add a Capacity Provider and Container Insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ for usage instructions.
 | egress_cidrs                               | The CIDRs accessible from containers                                                                             | ["0.0.0.0/0"]      | if include_default_egress_rule is "yes"  | 
 | launch_configuration_create_before_destroy | Whether or not to destroy the launch configuration before creating a new one ("yes" or "no")                     | "yes"              | no                                       |
 | security_groups                            | The list of security group IDs to associate with the cluster in addition to the default security group           | []                 | no                                       |
+| container_insights                         | Whether or not Container Insights should be enabled ("enabled" or "disabled").                                   | "enabled"          | no
 
 Notes:
 * By default, the latest available Amazon Linux 2 AMI is used.
@@ -130,6 +131,7 @@ Notes:
 | service_policy_arn        | The ARN of the ECS service policy                                                |
 | service_policy_id         | The ID of the ECS service policy                                                 |
 | log_group                 | The name of the default log group for the cluster                                |
+| capacity_provider_name    | The name of the cluster's capacity provider                                      |
 
 ### Required Permissions
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -72,3 +72,8 @@ output "log_group" {
   description = "The name of the default log group for the cluster."
   value = aws_cloudwatch_log_group.cluster.name
 }
+
+output "capacity_provider_name" {
+  description = "The name of the cluster's capacity provider"
+  value       = aws_ecs_capacity_provider.cluster.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -137,3 +137,9 @@ variable "security_groups" {
   type = list(string)
   default = []
 }
+
+variable "container_insights" {
+  description = "Whether or not Container Insights should be enabled (\"enabled\" or \"disabled\")."
+  type = string
+  default = "enabled"
+}


### PR DESCRIPTION
This PR adds a Capacity Provider resource to the ECS Cluster as well as turning on Container Insights by default.
