### PR TITLE
Make module `darwin_arm64` compatible

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -5,13 +5,13 @@ resource "aws_iam_role" "cluster_instance_role" {
   tags = local.tags
 }
 
-data "template_file" "cluster_instance_policy" {
-  template = file("${path.module}/policies/cluster-instance-policy.json")
+locals {
+  template_cluster_instance_policy = file("${path.module}/policies/cluster-instance-policy.json")
 }
 
 resource "aws_iam_policy" "cluster_instance_policy" {
   description = "cluster-instance-policy-${var.component}-${var.deployment_identifier}-${var.cluster_name}"
-  policy      = coalesce(var.cluster_instance_iam_policy_contents, data.template_file.cluster_instance_policy.rendered)
+  policy      = coalesce(var.cluster_instance_iam_policy_contents, local.template_cluster_instance_policy)
 }
 
 resource "aws_iam_policy_attachment" "cluster_instance_policy_attachment" {

--- a/spec/infra/harness/terraform.tf
+++ b/spec/infra/harness/terraform.tf
@@ -10,9 +10,5 @@ terraform {
       source = "hashicorp/null"
       version = "~> 3.0"
     }
-    template = {
-      source = "hashicorp/template"
-      version = "~> 2.2"
-    }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -10,9 +10,5 @@ terraform {
       source = "hashicorp/null"
       version = "~> 3.0"
     }
-    template = {
-      source = "hashicorp/template"
-      version = "~> 2.2"
-    }
   }
 }


### PR DESCRIPTION
Remove deprecated "Template Provider" Provider (see: https://registry.terraform.io/providers/hashicorp/template/latest/docs)
and use instead terraforms `locals` block and `templatefile` function.

resolve #30